### PR TITLE
fix: resolve bugs and improve code quality across the codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-test-runner-performance",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -18,7 +18,7 @@
   },
   "files": [
     "dist",
-    "LICENSE.md",
+    "LICENSE",
     "README.md",
     "llms.txt"
   ],

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -16,7 +16,7 @@ export async function testRenderTime(template: TemplateResult<1>, config: { iter
   }
 
   const duration = averages.reduce((p, n) => p + n.entry.duration, 0) / conf.average;
-  const result = { duration, iterations: config.iterations, average: config.average };
+  const result = { duration, iterations: conf.iterations, average: conf.average };
   await executeServerCommand<any, any>('performance:render', result);
   return result;
 }
@@ -35,22 +35,28 @@ async function* averageRender(template: TemplateResult<1>, config: { iterations:
   }
 }
 
-export function measureElementRender(element: HTMLElement, markId = `_${Math.random().toString(36).substr(2, 9)}`) {
-  return new Promise(resolve => {
+export function measureElementRender(element: HTMLElement, markId = `_${Math.random().toString(36).substring(2, 11)}`, timeout = 10000) {
+  return new Promise((resolve, reject) => {
     performance.mark(`${markId}-start`);
+
+    const timeoutId = setTimeout(() => {
+      observer.disconnect();
+      reject(new Error(`measureElementRender timed out after ${timeout}ms: element did not reach non-zero dimensions`));
+    }, timeout);
 
     const observer = new ResizeObserver(async (mutation) => {
       const { width, height } = mutation[0].contentRect;
       if (width > 0 && height > 0) {
+        clearTimeout(timeoutId);
         observer.disconnect();
         await new Promise(r => setTimeout(() => r('')));
         performance.mark(`${markId}-end`);
         performance.measure(markId, `${markId}-start`, `${markId}-end`);
-  
+
         const entry = performance.getEntriesByName(markId).pop();
         const duration = Number.parseFloat(entry.duration.toPrecision(5));
         const detail = { entry: { ...entry, duration } };
-  
+
         performance.clearMarks(`${markId}-start`);
         performance.clearMarks(`${markId}-end`);
         performance.clearMeasures(markId);

--- a/src/index.performance.ts
+++ b/src/index.performance.ts
@@ -13,4 +13,11 @@ describe('performance', () => {
     const result = await testRenderTime(html`<p>hello world</p>`, { iterations: 1000, average: 10 });
     expect(result.duration).toBeLessThan(50);
   });
+
+  it('should use default iterations and average when not specified', async () => {
+    const result = await testRenderTime(html`<p>default config</p>`);
+    expect(result.iterations).toBe(1);
+    expect(result.average).toBe(3);
+    expect(result.duration).toBeGreaterThan(0);
+  });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -123,6 +123,36 @@ describe('bundlePerformancePlugin', () => {
     assert.ok(result.kb > 0, 'bundle size should be greater than 0');
   });
 
+  it('should handle RegExp aliases without anchors', async () => {
+    const plugin = bundlePerformancePlugin({
+      aliases: [{ find: /demo-module/, replacement: './demo-module' }]
+    });
+
+    const result = await plugin.executeCommand({
+      command: 'performance:bundle',
+      payload: { bundle: 'demo-module/index.js', config: {} },
+      session: createSession('test-regex-no-anchors')
+    });
+
+    assert.ok(result, 'should return a result');
+    assert.ok(result.kb > 0, 'should handle regex without anchors');
+  });
+
+  it('should handle RegExp aliases with only start anchor', async () => {
+    const plugin = bundlePerformancePlugin({
+      aliases: [{ find: /^demo-module/, replacement: './demo-module' }]
+    });
+
+    const result = await plugin.executeCommand({
+      command: 'performance:bundle',
+      payload: { bundle: 'demo-module/index.js', config: {} },
+      session: createSession('test-regex-start-anchor')
+    });
+
+    assert.ok(result, 'should return a result');
+    assert.ok(result.kb > 0, 'should handle regex with start anchor only');
+  });
+
   it('should write output files when writePath is provided', async () => {
     const writePath = './dist/test-output';
 
@@ -172,7 +202,7 @@ describe('renderPerformancePlugin', () => {
 
     const result = await plugin.executeCommand({
       command: 'performance:render',
-      payload: { duration: 25.5, averages: [25, 26], iterations: 1000 },
+      payload: { duration: 25.5, average: 3, iterations: 1000 },
       session
     });
 
@@ -188,11 +218,55 @@ describe('renderPerformancePlugin', () => {
 
     const result = await plugin.executeCommand({
       command: 'performance:render',
-      payload: { duration: 10, averages: [10], iterations: 500 },
+      payload: { duration: 10, average: 1, iterations: 500 },
       session
     });
 
     assert.strictEqual(result, 'reported');
+  });
+});
+
+describe('store accumulation', () => {
+  it('should accumulate bundle and render data in the report', () => {
+    const writePath = './dist/test-accumulation';
+    const reporter = performanceReporter({ writePath });
+    reporter.stop();
+
+    const reportPath = path.join(writePath, 'report.json');
+    const report = fs.readJsonSync(reportPath);
+
+    assert.ok(report.bundleSizes.length > 0, 'should have accumulated bundle sizes from prior tests');
+    assert.ok(report.renderTimes.length > 0, 'should have accumulated render times from prior tests');
+
+    for (const entry of report.bundleSizes) {
+      assert.ok(typeof entry.kb === 'number', 'bundle entry should have kb as number');
+      assert.ok(typeof entry.testFile === 'string', 'bundle entry should have testFile');
+      assert.strictEqual(entry.compression, 'brotli', 'bundle entry should have brotli compression');
+      assert.ok(typeof entry.entrypoint === 'string', 'bundle entry should have entrypoint');
+    }
+
+    for (const entry of report.renderTimes) {
+      assert.ok(typeof entry.testFile === 'string', 'render entry should have testFile');
+      assert.ok(typeof entry.duration === 'number', 'render entry should have duration');
+      assert.ok(typeof entry.average === 'number', 'render entry should have average');
+      assert.ok(typeof entry.iterations === 'number', 'render entry should have iterations');
+    }
+
+    fs.removeSync(writePath);
+  });
+
+  it('should reset the store after reporter.stop() is called', () => {
+    const writePath = './dist/test-reset';
+    const reporter = performanceReporter({ writePath });
+    reporter.stop();
+
+    const reportPath = path.join(writePath, 'report.json');
+    const report = fs.readJsonSync(reportPath);
+
+    assert.strictEqual(report.renderTimes.length, 0, 'store should be empty after prior stop() reset');
+    assert.strictEqual(report.bundleSizes.length, 0, 'store should be empty after prior stop() reset');
+
+    fs.removeSync(writePath);
   });
 });
 


### PR DESCRIPTION
- Fix render data bug: use conf (with defaults) instead of raw config
  for returned iterations/average values in testRenderTime (browser.ts)
- Fix property name mismatch: server reads payload.average instead of
  payload.averages to match what the browser sends (index.ts)
- Add BundleConfig type annotation to bundlePerformancePlugin parameter
- Add explicit types to measureRenderTime session and payload parameters
- Fix shadowed path variable in performanceReporter (rename to reportPath)
  and use path.join for proper path construction
- Replace `as any` cast with type guard for CSS asset detection
- Add try/finally around rolldown pipeline to ensure bundle.close() runs
- Add timeout to measureElementRender to prevent hanging promises
- Add store reset after reporter writes to prevent data bleed across runs
- Fix LICENSE.md -> LICENSE in package.json files array
- Add tests for store accumulation, store reset, and RegExp alias patterns
- Add browser test for default testRenderTime config values
- Update test payloads to use correct property name (average vs averages)

https://claude.ai/code/session_01Qx5BGgWeYmPTnb8kwb56rg